### PR TITLE
Update to Cerbos v0.39.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725432240,
-        "narHash": "sha256-+yj+xgsfZaErbfYM3T+QvEE2hU7UuE+Jf0fJCJ8uPS0=",
+        "lastModified": 1727634051,
+        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad416d066ca1222956472ab7d0555a6946746a80",
+        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        version = "0.38.1";
+        version = "0.39.0";
         commit = if (builtins.hasAttr "rev" self) then self.rev else "unknown";
       in
       {
@@ -21,7 +21,7 @@
               repo = "cerbos";
               rev = "v${version}";
               # Obtain with `nix flake prefetch github:cerbos/cerbos/v0.38.1`
-              sha256 = "sha256-Ku6khVn+lWLk03IhG9tpJpK/mEwt9/0UV+BfhSJ7wvY=";
+              sha256 = "sha256-r6wIBz1XUDjmf8kuM+zev/yrf6m1c87oOMSQBc90pfg=";
             };
 
             subPackages = [


### PR DESCRIPTION
Note: The version of Go available on nixpkgs is still stuck at 1.22.7
and it won't build this flake because Cerbos requires Go 1.23. Merge
when https://github.com/NixOS/nixpkgs/issues/344827 is resolved.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
